### PR TITLE
Add price preprocessing helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ The code provided here is for e.g. financial time series data. It implements the
 - `onedim.ipynb`: Notebook for one-dimensional financial time series data, such as stock prices or index returns.
 - `multidim.ipynb`: Notebook for multidimensional financial time series data, such as image sequences or high-dimensional market data.
 
+## Preprocessing price data
+Use the `preprocess_prices` helper to transform raw price series into the array format expected by `SchrodingerBridge`.
+
+```python
+from src.preprocess import preprocess_prices
+
+windows = preprocess_prices(data["Adj Close"], window_size=60)
+bridge = SchrodingerBridge(distSize=60, nbpaths=windows.shape[0],
+                           timeSeriesData=windows)
+```
+
+
 ## Running the notebooks and scripts
 1. Activate your environment and install the requirements as shown above.
 2. Start Jupyter and open the desired notebook:

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -1,0 +1,61 @@
+import numpy as np
+import pandas as pd
+
+
+def preprocess_prices(prices, window_size, log_returns=True):
+    """Return time series windows for :class:`SchrodingerBridge`.
+
+    Parameters
+    ----------
+    prices : pandas.Series, pandas.DataFrame or array-like
+        Raw price observations. If a ``DataFrame`` is provided, all columns
+        will be processed.
+    window_size : int
+        Length of each rolling window (``N``).
+    log_returns : bool, optional
+        If ``True`` (default), compute log returns of the normalised prices.
+        When ``False`` the normalised price paths are returned instead.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of shape ``(M, window_size + 1, D)`` with ``M`` windows and
+        ``D`` features. When ``D`` equals 1 the trailing dimension is
+        squeezed. The first column is zero when ``log_returns`` is ``True``.
+
+    Examples
+    --------
+    >>> import yfinance as yf
+    >>> from src.preprocess import preprocess_prices
+    >>> data = yf.download("MSFT", start="2010-01-01", end="2020-01-30")
+    >>> windows = preprocess_prices(data["Adj Close"], window_size=60)
+    >>> sb = SchrodingerBridge(distSize=60, nbpaths=windows.shape[0],
+    ...                        timeSeriesData=windows)
+    """
+    arr = np.asarray(prices)
+    if isinstance(prices, (pd.Series, pd.DataFrame)):
+        arr = prices.values
+    if arr.ndim == 1:
+        arr = arr[:, None]
+
+    if arr.shape[0] < window_size + 1:
+        raise ValueError("window_size larger than number of observations")
+
+    # Build rolling windows
+    view = np.lib.stride_tricks.sliding_window_view(arr, window_size + 1, axis=0)
+    windows = view.reshape(-1, window_size + 1, arr.shape[1])
+
+    # Normalise by first value in each window
+    norm = windows / windows[:, :1, :]
+
+    if log_returns:
+        log_ret = np.zeros_like(norm)
+        log_ret[:, 1:, :] = np.diff(np.log(norm), axis=1)
+        result = log_ret
+    else:
+        result = norm
+
+    if result.shape[2] == 1:
+        result = result[:, :, 0]
+
+    return result


### PR DESCRIPTION
## Summary
- implement `preprocess_prices` helper in `src/preprocess.py`
- document preprocessing usage in README

## Testing
- `python -m py_compile src/preprocess.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e1ea3c5888322819d82f85535065e